### PR TITLE
change closures to allow bounding to parameters

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
 		"strict": [2, "global"],
 		"quotes": [2, "double", "avoid-escape"],
 		"indent": [1, "tab"],
-		"no-unused-vars": 1
+		"no-unused-vars": [1, {"args": "none"}]
 	},
 	"globals": {
 	}

--- a/lib/Context.js
+++ b/lib/Context.js
@@ -1,9 +1,12 @@
 "use strict";
 
+const util = require("./util");
+
 module.exports = class Context {
 
 	constructor(engine) {
 		this.engine = engine;
+		this.parameters = {};
 		this.rulesFired = [];
 		this._ruleFlowTree = [];
 		this._currentRuleFlowActivated = false;
@@ -30,6 +33,22 @@ module.exports = class Context {
 	ruleFired(rule) {
 		this.rulesFired.push(rule);
 		this._currentRuleFlowActivated = true;
+	}
+
+	bindParameters(newParameters) {
+		const newParametersKeys = Object.keys(newParameters);
+		if (newParametersKeys.length === 0) {
+			return this.parameters;
+		}
+
+		const oldParameters = this.parameters;
+		this.parameters = util.clone(this.parameters);
+		newParametersKeys.forEach(key => this.parameters[key] = newParameters[key]);
+		return oldParameters;
+	}
+
+	restore(oldParameters) {
+		this.parameters = oldParameters;
 	}
 
 }

--- a/lib/Engine.js
+++ b/lib/Engine.js
@@ -2,13 +2,18 @@
 
 const wrap = require("async-class-co").wrap,
 	Context = require("./Context"),
-	ClosureFactory = require("./closure/ClosureFactory")
+	ClosureRegistry = require("./closure/ClosureRegistry")
 
 class Engine {
 
 	constructor() {
 		this.context = {};
-		this.closures = new ClosureFactory(this);
+		this.closures = new ClosureRegistry(this);
+	}
+
+	add(definition) {
+		const closure = this.closures.create(definition);
+		closure.name && this.closures.addNamedClosure(closure);
 	}
 
 	* process(closure, fact) {

--- a/lib/closure/Closure.js
+++ b/lib/closure/Closure.js
@@ -1,0 +1,70 @@
+"use strict";
+
+/**
+ * A closure that its identified by a name. All closures expose the method
+ * process(fact, context) that allows them to operate as predicates or
+ * transfomers of a certain fact.
+ *
+ * @type {Closure}
+ */
+class Closure {
+
+	constructor(name) {
+		this.name = name;
+	}
+
+	get named() {
+		return !!this.name;
+	}
+
+	/**
+	 * Evaluates the block against a fact promise
+	 * @param {Object} fact 						a fact
+	 * @param {Context} context					an execution context.
+	 * @param {Context} context.engine	the rules engine
+	 *
+	 * @return {Promise} a promise that will be resolved to some result
+	 */
+	process(fact, context) {
+		throw new Error("This is an abstract closure, how did you get to instantiate this?");
+	}
+
+	/**
+	 * Bounds this closure to a set of parameters. This will return a new Closure than
+	 * when invoked it will ALWAYS pass the given parameters as a fields inside the
+	 * context.parameters object.
+	 *
+	 * @param {String} name - the name, if specified, of the resulting bounded closure
+	 * @param {Object} parameters - the parameters to bound to the closure
+	 * @param {Engine} engine - the rules engine instance
+	 */
+	bound(name, parameters, engine) {
+		return new BoundClosure(name, this, parameters)
+	}
+
+}
+
+
+/**
+ * A closure bound to a certain set of parameters
+ * @type
+ */
+class BoundClosure extends Closure {
+
+	constructor(name, closure, parameters) {
+		super(name);
+		this.closure = closure;
+		this.parameters = parameters || {};
+	}
+
+	process(fact, context) {
+		const oldParameters = context.bindParameters(this.parameters);
+		return this.closure.process(fact, context).then(r => {
+			context.restore(oldParameters);
+			return r;
+		});
+	}
+
+}
+
+module.exports = Closure;

--- a/lib/closure/ClosureReducer.js
+++ b/lib/closure/ClosureReducer.js
@@ -1,6 +1,7 @@
 "use strict";
 
-const wrap = require("async-class-co").wrap;
+const Closure = require("./Closure"),
+	wrap = require("async-class-co").wrap;
 
 /**
  * This is a closure composite that will reduce the fact execution through
@@ -8,9 +9,10 @@ const wrap = require("async-class-co").wrap;
  * be used as fact for the next closure.
  * @type {ClosureReducer}
  */
-class ClosureReducer {
+class ClosureReducer extends Closure {
 
-	constructor(closures) {
+	constructor(name, closures) {
+		super(name);
 		this.closures = closures;
 	}
 

--- a/lib/closure/ClosureRegistry.js
+++ b/lib/closure/ClosureRegistry.js
@@ -13,39 +13,28 @@ const ProvidedClosure = require("./ProvidedClosure"),
  * It also acts as a registry for named-closure implementations which need to
  * be provided before parsing any named closure.
  *
- * TODO: any closure that is bound to a name should be registered to be
- * used later! That way we can do engine.process(<closureName>, fact) instead
- * of having to keep reference to rules object.
- *
- * @type {Closure}
+ * @type {ClosureRegistry}
  */
-module.exports = class ClosureFactory {
+module.exports = class ClosureRegistry {
 
 	constructor(engine) {
 		this.engine = engine;
-		this.providedClosures = {};
+		this.namedClosures = {};
 	}
 
-	addProvidedClosureImpl(name, closureImpl, { requiredParameters, mapParameters } = {}) {
-		if (this.providedClosures[name]) {
-			throw new Error(`Already defined a provided closure with name ${name}`);
+	add(closure) {
+		this.namedClosures[closure.name] = closure;
+	}
+
+	addProvidedClosureImpl(name, implementation, options) {
+		if (this.namedClosures[name]) {
+			throw new Error(`Already defined a closure with name '${name}'`);
+		}
+		if (typeof(implementation) !== "function") {
+			throw new TypeError(`Implementation for provided closure '${name}' is not a function`);
 		}
 
-		if (typeof(closureImpl) !== "function") {
-			throw new TypeError(`Implementation for provided closure ${name} is not a function`);
-		}
-
-		this.providedClosures[name] = params => {
-			const missing = (requiredParameters || []).find(required => params[required] === undefined)
-			if (missing) {
-				throw new Error(`Cannot instantiate provided closure ${name}. Parameter ${missing} is unbounded`);
-			}
-
-			if (mapParameters) {
-				params = mapParameters(params, this.engine);
-			}
-			return new ProvidedClosure(name, closureImpl, params);
-		}
+		this.namedClosures[name] = new ProvidedClosure(name, implementation, options);
 	}
 
 	/**
@@ -70,48 +59,47 @@ module.exports = class ClosureFactory {
 	 */
 	create(definition) {
 		if (Array.isArray(definition)) {
-			return this.createReducer(definition); //closure reducer for arrays
+			return this._createReducer(definition); //closure reducer for arrays
 		} else if (definition.rules) {
-			return this.createRuleFlow(definition);
+			return this._createRuleFlow(definition);
 		} else if (definition.when || definition.then) {
-			return this.createRule(definition);
+			return this._createRule(definition);
 		} else {
-			return this.createProvidedClosure(definition);
+			return this._createNamedClosure(definition);
 		}
 	}
 
-	createReducer(definition) {
+	_createReducer(definition) {
 		const closures = definition.map(eachDefinition => this.create(eachDefinition));
-		return new ClosureChain(closures);
+		return new ClosureChain(definition.name, closures);
 	}
 
-	createRule(definition) {
-		if (! definition.when) throw new Error(`Rule ${definition.name} must define a valid when clause`);
-		if (! definition.then) throw new Error(`Rule ${definition.name} must define a valid then clause`);
+	_createRule(definition) {
+		if (! definition.when) throw new Error(`Rule '${definition.name}' must define a valid when clause`);
+		if (! definition.then) throw new Error(`Rule '${definition.name}' must define a valid then clause`);
 
 		const condition = this.create(definition.when);
 		const action = this.create(definition.then);
 		return new Rule(definition.name, condition, action);
 	}
 
-	createRuleFlow(definition) {
+	_createRuleFlow(definition) {
 		const closures = definition.rules.map(eachDefinition => this.create(eachDefinition));
 		return new RuleFlow(definition.name, closures);
 	}
 
-	createProvidedClosure(definition) {
-		definition = typeof(definition) === "string" ? { closure: definition } : definition; //code-sugar
+	_createNamedClosure(definition) {
+		definition = typeof(definition) === "string" ? { closure: definition } : definition;
 
-		const closureFactory = this.providedClosures[definition.closure];
-		if (! closureFactory) {
-			throw new Error(`Cannot find a provided closure named ${definition.closure}`);
+		const closure = this.namedClosures[definition.closure];
+		if (! closure) {
+			throw new Error(`Cannot find a named closure named '${definition.closure}'`);
 		}
 
 		let parameters = util.clone(definition);
 		delete parameters.closure;
 
-		return closureFactory(parameters);
+		return closure.bound(definition.name, parameters, this.engine);
 	}
-
 
 }

--- a/lib/closure/ProvidedClosure.js
+++ b/lib/closure/ProvidedClosure.js
@@ -1,27 +1,24 @@
 "use strict";
 
+const Closure = require("./Closure");
+
 /**
- * A simple closure that its identified by a name, bound to a certain set of
- * execution parameters and implemented through a function that is defined
+ * A simple closure that's implemented through a function that is defined
  * in beforehand.
  *
  * @type {ProvidedClosure}
  */
-class ProvidedClosure {
+class ProvidedClosure extends Closure {
 
 	/**
 	 * @param  {string}   name       the name of the clousre
 	 * @param  {Function} fn         a function providing an implementation
 	 *                               for this closure.
-	 * @param  {Object}   parameters a set of bound parameters that will be
-	 *                               provided to the closure function, allowing
-	 *                               the possibility of reusing implementation
-	 *                               functions.
 	 */
-	constructor(name, fn, parameters) {
-		this.name = name;
+	constructor(name, fn, options = {}) {
+		super(name);
 		this.fn = fn;
-		this.parameters = parameters;
+		this.options = options;
 	}
 
 	/**
@@ -33,8 +30,23 @@ class ProvidedClosure {
 	 * @return {Promise} a promise that will be resolved to some result
 	 */
 	process(fact, context) {
-		const result = this.fn.call(this, fact, this.parameters, context);
+		const result = this.fn.call(this, fact, context);
 		return Promise.resolve(result);
+	}
+
+	bound(name, parameters, engine) {
+		const missing = (this.options.requiredParameters || []).find(required => parameters[required] === undefined)
+		if (missing) {
+			throw new Error(`Cannot instantiate provided closure '${this.name}'. Parameter ${missing} is unbounded`);
+		}
+
+		// Replaces parameters that are set as closureParamters with actual closures!
+		if (this.options.closureParameters) {
+			this.options.closureParameters.forEach(parameter => {
+				parameters[parameter] = engine.closures.create(parameters[parameter]);
+			})
+		}
+		return super.bound(name, parameters, engine);
 	}
 
 }

--- a/lib/closure/Rule.js
+++ b/lib/closure/Rule.js
@@ -1,6 +1,7 @@
 "use strict";
 
-const wrap = require("async-class-co").wrap;
+const Closure = require("./Closure"),
+	wrap = require("async-class-co").wrap;
 
 /**
  * A rule is a named conditional closure. It understands the `process` message
@@ -9,10 +10,10 @@ const wrap = require("async-class-co").wrap;
  *
  * @type {Rule}
  */
-class Rule {
+class Rule extends Closure{
 
 	constructor(name, condition, action) {
-		this.name = name;
+		super(name);
 		this.condition = condition;
 		this.action = action;
 	}

--- a/lib/closure/RuleFlow.js
+++ b/lib/closure/RuleFlow.js
@@ -5,11 +5,6 @@ const wrap = require("async-class-co").wrap,
 
 class RuleFlow extends ClosureReducer {
 
-	constructor(name, closures) {
-		super(closures);
-		this.name = name;
-	}
-
 	* process(fact, context) {
 		context.initiateFlow();
 		fact = yield super.process(fact, context);

--- a/lib/common/action/error.js
+++ b/lib/common/action/error.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = engine => {
-	engine.closures.addProvidedClosureImpl("error", (fact, params) => { throw new Error(params.message) }, {
+	engine.closures.addProvidedClosureImpl("error", (fact, context) => { throw new Error(context.parameters.message) }, {
 		requiredParameters: ["message"]
 	});
 }

--- a/lib/common/action/setResult.js
+++ b/lib/common/action/setResult.js
@@ -3,17 +3,14 @@
 const co = require("co");
 
 module.exports = engine => {
-	const fn = co.wrap(function *(fact, params, context) {
-		const value = yield params.calculator.process(fact, params, context);
-		fact[params.field] = value;
+	const fn = co.wrap(function *(fact, context) {
+		const value = yield context.parameters.calculator.process(fact, context);
+		fact[context.parameters.field] = value;
 		return fact;
 	});
 
 	engine.closures.addProvidedClosureImpl("setResult", fn, {
 		requiredParameters: ["field", "calculator"],
-		mapParameters: (params, engine) => {
-			params.calculator = engine.closures.create(params.calculator);
-			return params;
-		}
+		closureParameters: [ "calculator" ]
 	});
 }

--- a/lib/common/condition/default.js
+++ b/lib/common/condition/default.js
@@ -2,5 +2,5 @@
 
 module.exports = engine => {
 	//Executes only if NO other rule has been executed for this flow
-	engine.closures.addProvidedClosureImpl("default", (fact, params, context) => ! context.currentRuleFlowActivated );
+	engine.closures.addProvidedClosureImpl("default", (fact, context) => ! context.currentRuleFlowActivated );
 }

--- a/lib/common/condition/equal.js
+++ b/lib/common/condition/equal.js
@@ -3,9 +3,9 @@
 module.exports = engine => {
 	//Matches only if certain fact field (specified by field) equals to some
 	//other specified value
-	const fn = (fact, params) => {
-		const factValue = params.field ? fact[params.field] : fact;
-		return factValue === params.value
+	const fn = (fact, context) => {
+		const factValue = context.parameters.field ? fact[context.parameters.field] : fact;
+		return factValue === context.parameters.value
 	};
 
 	engine.closures.addProvidedClosureImpl("equal", fn, {

--- a/test/ClosureRegistry.test.js
+++ b/test/ClosureRegistry.test.js
@@ -9,7 +9,7 @@ chai.use(chaiPromised);
 
 const trueFn = () => true
 
-describe("ClosureFactory", () => {
+describe("ClosureRegistry", () => {
 
 	let engine
 
@@ -34,21 +34,21 @@ describe("ClosureFactory", () => {
 
 		it("shouldn't do any validation for parameterless closures", () => {
 			engine.closures.addProvidedClosureImpl("true", trueFn);
-			engine.closures.createProvidedClosure("true"); //does nothing
+			engine.closures._createNamedClosure("true"); //does nothing
 		});
 
 		it("shouln't fail if required parmeters are provided ", () => {
 			engine.closures.addProvidedClosureImpl("equal", trueFn, { requiredParameters: ["field", "value"] });
-			engine.closures.createProvidedClosure({ "closure": "equal", "field": "foo", "value": "bar" });
+			engine.closures._createNamedClosure({ "closure": "equal", "field": "foo", "value": "bar" });
 		});
 
 		it("should fail if implementation does not exists", () => {
-			(() => engine.closures.createProvidedClosure("true")).should.throw();
+			(() => engine.closures._createNamedClosure("true")).should.throw();
 		});
 
 		it("should fail if any of required parameters is missing", () => {
 			engine.closures.addProvidedClosureImpl("equal", trueFn, { requiredParameters: ["field", "value"] });
-			(() => engine.closures.createProvidedClosure({ "closure": "equal", "field": "foo" })).should.throw();
+			(() => engine.closures._createNamedClosure({ "closure": "equal", "field": "foo" })).should.throw();
 		});
 
 	});

--- a/test/Rule.test.js
+++ b/test/Rule.test.js
@@ -56,7 +56,7 @@ describe("Rule", () => {
 		let rule;
 
 		beforeEach(() => {
-			engine.closures.addProvidedClosureImpl("setFoo", (fact, parameters) => {
+			engine.closures.addProvidedClosureImpl("setFoo", (fact, { parameters }) => {
 				fact.foo = parameters.value;
 				return fact;
 			}, { requiredParameters: ["value"] });
@@ -100,7 +100,7 @@ describe("Rule", () => {
 		let rule;
 
 		beforeEach(() => {
-			engine.closures.addProvidedClosureImpl("newFact", (fact, parameters) => {
+			engine.closures.addProvidedClosureImpl("newFact", (fact, { parameters }) => {
 				return fact + parameters.value; //concatenates fact value with parameter value
 			}, { requiredParameters: ["value"] });
 
@@ -127,7 +127,7 @@ describe("Rule", () => {
 				return fact.body; //extracts the body out of the fact
 			});
 
-			engine.closures.addProvidedClosureImpl("newFact", (fact, parameters) => {
+			engine.closures.addProvidedClosureImpl("newFact", (fact, { parameters }) => {
 				return fact + parameters.value; //concatenates fact value with parameter value
 			}, { requiredParameters: ["value"] });
 
@@ -156,7 +156,7 @@ describe("Rule", () => {
 				return fact.testField; //extracts the testField out of the fact, it becomes the new fact!
 			});
 
-			engine.closures.addProvidedClosureImpl("setFoo", (fact, parameters) => {
+			engine.closures.addProvidedClosureImpl("setFoo", (fact, { parameters }) => {
 				fact.foo = parameters.value;
 				return fact;
 			}, { requiredParameters: ["value"] });
@@ -197,7 +197,7 @@ describe("Rule", () => {
 		let rule;
 
 		beforeEach(() => {
-			engine.closures.addProvidedClosureImpl("setFoo", (fact, parameters) => {
+			engine.closures.addProvidedClosureImpl("setFoo", (fact, { parameters }) => {
 				fact.foo = parameters.value;
 				return fact;
 			}, { requiredParameters: ["value"] });
@@ -247,7 +247,7 @@ describe("Rule", () => {
 		let rule;
 
 		beforeEach(() => {
-			engine.closures.addProvidedClosureImpl("setFoo", (fact, parameters) => {
+			engine.closures.addProvidedClosureImpl("setFoo", (fact, { parameters }) => {
 				fact.foo = parameters.value;
 				return fact;
 			}, { requiredParameters: ["value"] });
@@ -303,7 +303,7 @@ describe("Rule", () => {
 		let rule;
 
 		beforeEach(() => {
-			engine.closures.addProvidedClosureImpl("setFoo", (fact, parameters) => {
+			engine.closures.addProvidedClosureImpl("setFoo", (fact, { parameters }) => {
 				fact.foo = parameters.value;
 				return fact;
 			}, { requiredParameters: ["value"] });
@@ -339,7 +339,7 @@ describe("Rule", () => {
 	describe("misconfigured rules", () => {
 
 		it("should fail if required parameter of action/condition is not provided", () => {
-			engine.closures.addProvidedClosureImpl("setFoo", (fact, parameters) => {
+			engine.closures.addProvidedClosureImpl("setFoo", (fact, { parameters }) => {
 				fact.foo = parameters.value;
 				return fact;
 			}, { requiredParameters: ["value"] });

--- a/test/rules/index.js
+++ b/test/rules/index.js
@@ -7,10 +7,11 @@ const engine = new Engine();
 commmons(engine);
 
 //productTypeCondition - not really needed, generic equal can be used instead
-engine.closures.addProvidedClosureImpl("productTypeCondition", (fact, {productType}) => fact.productType === productType);
+engine.closures.addProvidedClosureImpl("productTypeCondition",
+	(fact, { parameters }) => fact.productType === parameters.productType);
 
 //setQuantity
-engine.closures.addProvidedClosureImpl("fetchSecurityData", (fact, params, context) => {
+engine.closures.addProvidedClosureImpl("fetchSecurityData", (fact, context) => {
 	const securityPromise = context.engine.context.securityMasterSevice.fetch(fact.security);
 	return securityPromise.then(security => {
 		fact.security = security; //replaces security with full blown object
@@ -31,16 +32,19 @@ engine.closures.addProvidedClosureImpl("setCost", fact => {
 })
 
 //calculateCost - a version of setCost that returns not a fact but a simple value
-engine.closures.addProvidedClosureImpl("calculateCost", fact => fact.price * fact.quantity);
+engine.closures.addProvidedClosureImpl("calculateCost", fact => {
+	return fact.price * fact.quantity;
+});
 
 //setPercentualCommission
-engine.closures.addProvidedClosureImpl("setPercentualCommission", (fact, {percentualPoints}) => {
-	fact.commissions = fact.cost * percentualPoints / 100;
+engine.closures.addProvidedClosureImpl("setPercentualCommission", (fact, { parameters }) => {
+	fact.commissions = fact.cost * parameters.percentualPoints / 100;
 	return fact;
 }, { requiredParameters: ["percentualPoints"] })
 
 //calculateCommissions - a version of setCost that returns not a fact but a simple value
-engine.closures.addProvidedClosureImpl("calculatePercentualCommission", (fact, {percentualPoints}) => fact.cost * percentualPoints / 100,
-	{ requiredParameters: ["percentualPoints"] })
+engine.closures.addProvidedClosureImpl("calculatePercentualCommission", (fact, { parameters }) => {
+	return fact.cost * parameters.percentualPoints / 100;
+}, { requiredParameters: ["percentualPoints"] })
 
 module.exports = engine;


### PR DESCRIPTION
Since this version all closures (not just leaf provided closures)
can be bounded to parameters.

This step is necessary to achieve a planned refactor that will allow
ANY closure to be referenced by its name.