### PR TITLE
closure parameters accept literal values

### DIFF
--- a/lib/closure/Closure.js
+++ b/lib/closure/Closure.js
@@ -57,7 +57,7 @@ class Closure {
 		// list
 		if (this.options.closureParameters) {
 			this.options.closureParameters.forEach(parameter => {
-				parameters[parameter] = engine.closures.parse(parameters[parameter]);
+				parameters[parameter] = engine.closures.parseOrValue(parameters[parameter]);
 			})
 		}
 

--- a/lib/closure/ClosureRegistry.js
+++ b/lib/closure/ClosureRegistry.js
@@ -93,6 +93,24 @@ module.exports = class ClosureRegistry {
 		}
 	}
 
+	parseOrValue(definition) {
+		// if it is exactly undefined: do nothing
+		if (definition === undefined) {
+			return definition
+		}
+
+		// rule out the "value" case: it is a falsy value a number, an Array, or a String which is not the name of a registered closure
+		// in such cases, I return in fact a fixedValue closure for the given value
+		if (!definition || (typeof definition === "number") || Array.isArray(definition)
+			|| ((typeof definition === "string") && !this.namedClosures[definition])
+		) {
+			return this.namedClosures["fixedValue"].bind(null, {value: definition}, null)  // no engine needed
+		}
+
+		// it is a true definition
+		return this.parse(definition)
+	}
+
 	_createReducer(definition, options) {
 		const closures = definition.map(eachDefinition => this.parse(eachDefinition));
 		return new ClosureReducer(definition.name, closures, options);


### PR DESCRIPTION
As indicated in the title, with this change, even when a parameter is defined as closureParameter, it still accepts a fixed value. A nice thing is that the value for such parameters is always a closure; if a fixed value is detected, then it is wrapped in a fixedValue built-in closure.