### PR TITLE
Daterange empowered

### DIFF
--- a/lib/closure/Closure.js
+++ b/lib/closure/Closure.js
@@ -57,7 +57,7 @@ class Closure {
 		// list
 		if (this.options.closureParameters) {
 			this.options.closureParameters.forEach(parameter => {
-				parameters[parameter] = engine.closures.parse(parameters[parameter]);
+				parameters[parameter] = engine.closures.parseOrValue(parameters[parameter]);
 			})
 		}
 

--- a/lib/closure/ClosureRegistry.js
+++ b/lib/closure/ClosureRegistry.js
@@ -93,6 +93,24 @@ module.exports = class ClosureRegistry {
 		}
 	}
 
+	parseOrValue(definition) {
+		// if it is exactly undefined: do nothing
+		if (definition === undefined) {
+			return definition
+		}
+
+		// rule out the "value" case: it is a falsy value a number, an Array, or a String which is not the name of a registered closure
+		// in such cases, I return in fact a fixedValue closure for the given value
+		if (!definition || (typeof definition === "number") || Array.isArray(definition)
+			|| ((typeof definition === "string") && !this.namedClosures[definition])
+		) {
+			return this.namedClosures["fixedValue"].bind(null, {value: definition}, null)  // no engine needed
+		}
+
+		// it is a true definition
+		return this.parse(definition)
+	}
+
 	_createReducer(definition, options) {
 		const closures = definition.map(eachDefinition => this.parse(eachDefinition));
 		return new ClosureReducer(definition.name, closures, options);

--- a/lib/common/condition/dateRange.js
+++ b/lib/common/condition/dateRange.js
@@ -8,28 +8,38 @@ const moment = require("moment")
 class DateRange extends Closure {
 	process(fact, context) {
 		const dateInFact = this.getDateInFact(fact, context)
-		const dateFrom = this.getDateFromParam("dateFrom", context)
-		const dateTo = this.getDateFromParam("dateTo", context)
+		const dateFrom = this.getDateFromParam("dateFrom", fact, context)
+		const dateTo = this.getDateFromParam("dateTo", fact, context)
+		const dateBefore = this.getDateFromParam("dateBefore", fact, context)
+		const dateAfter = this.getDateFromParam("dateAfter", fact, context)
 		if (!dateInFact) { return false }
-		return (!dateFrom || dateFrom.isSameOrBefore(dateInFact)) && (!dateTo || dateTo.isSameOrAfter(dateInFact))
+		return (!dateFrom || dateInFact.isSameOrAfter(dateFrom))
+			&& (!dateTo || dateInFact.isSameOrBefore(dateTo))
+			&& (!dateBefore || dateInFact.isBefore(dateBefore))
+			&& (!dateAfter || dateInFact.isAfter(dateAfter))
 	}
 
 	getDateInFact(fact, context) {
 		const extractor = context.parameters.dateExtractor
 		const extractedValue = extractor.process(fact, context)
-		const extractedMoment = typeof(extractedValue) === "string" ? moment(extractedValue, "YYYY-MM-DD") : moment(extractedValue)
-		return extractedMoment
+		if (extractedValue) {
+			const extractedMoment = typeof(extractedValue) === "string" ? moment(extractedValue, "YYYY-MM-DD") : moment(extractedValue)
+			return extractedMoment
+		} else {
+			return null
+		}
 	}
 
-	getDateFromParam(paramName, context) {
-		const dateAsString = context.parameters[paramName]
+	getDateFromParam(paramName, fact, context) {
+		const dateSource = context.parameters[paramName]
+		const dateAsString = dateSource ? dateSource.process(fact, context) : null
 		return dateAsString ? moment(dateAsString, "YYYY-MM-DD") : null
 	}
 
 }
 
 DateRange.required = [ "dateExtractor" ];
-DateRange.closureParameters = [ "dateExtractor" ];
+DateRange.closureParameters = [ "dateExtractor", "dateFrom", "dateTo", "dateBefore", "dateAfter" ];
 
 
 module.exports = engine => {

--- a/test/closure/dateRange.test.js
+++ b/test/closure/dateRange.test.js
@@ -31,7 +31,21 @@ describe("dateRange", () => {
 
 			specificDateRangeClosure.should.not.be.null
 		});
+	});
 
+	describe("do not filter if no parameter date found in fact", () => {
+		it("no value given in fact", () => {
+			const rule = new Rule(
+				"incPrice",
+				engine.closures.get("dateRange").bind(null, {dateFrom: "2018-09-01", dateExtractor: "saleDate"}, engine),
+				engine.closures.get("priceInc")
+			)
+
+			const fact = { price: 10 }
+			const newFact = rule.process(fact, context())
+			newFact.should.not.be.null
+			newFact.price.should.equal(10)
+		});
 	});
 
 	describe("filter actions with dateFrom", () => {
@@ -127,7 +141,7 @@ describe("dateRange", () => {
 			newFact.price.should.equal(10)
 		});
 
-		it("should process on date on dateTo", () => {
+		it("should process on dateTo", () => {
 			const fact = { saleDate: niceDate(2018, 9, 30), price: 10 }
 			const newFact = rule.process(fact, context())
 			newFact.should.not.be.null
@@ -141,7 +155,7 @@ describe("dateRange", () => {
 			newFact.price.should.equal(11)
 		});
 
-		it("should process on date dateFrom", () => {
+		it("should process on dateFrom", () => {
 			const fact = { saleDate: niceDate(2018, 9, 1), price: 10 }
 			const newFact = rule.process(fact, context())
 			newFact.should.not.be.null
@@ -163,6 +177,103 @@ describe("dateRange", () => {
 		});
 
 	});
+
+	describe("filter actions with dateBefore", () => {
+		let rule
+
+		beforeEach("create rule", () => {
+			rule = new Rule(
+				"incPrice",
+				engine.closures.get("dateRange").bind(null, {dateBefore: "2018-09-01", dateExtractor: "saleDate"}, engine),
+				engine.closures.get("priceInc")
+			)
+		})
+
+		it("should not process on date way after dateBefore", () => {
+			const fact = { saleDate: "2018-10-15", price: 10 }
+			const newFact = rule.process(fact, context())
+			newFact.should.not.be.null
+			newFact.price.should.equal(10)
+		});
+
+		it("should not process on date just after dateBefore", () => {
+			const fact = { saleDate: "2018-09-02", price: 10 }
+			const newFact = rule.process(fact, context())
+			newFact.should.not.be.null
+			newFact.price.should.equal(10)
+		});
+
+		it("should not process on dateBefore", () => {
+			const fact = { saleDate: "2018-09-01", price: 10 }
+			const newFact = rule.process(fact, context())
+			newFact.should.not.be.null
+			newFact.price.should.equal(10)
+		});
+
+		it("should process on date just before dateBefore", () => {
+			const fact = { saleDate: "2018-08-31", price: 10 }
+			const newFact = rule.process(fact, context())
+			newFact.should.not.be.null
+			newFact.price.should.equal(11)
+		});
+
+		it("should process on date way before dateBefore", () => {
+			const fact = { saleDate: "2018-07-21", price: 10 }
+			const newFact = rule.process(fact, context())
+			newFact.should.not.be.null
+			newFact.price.should.equal(11)
+		});
+
+	});
+
+	describe("filter actions with dateAfter", () => {
+		let rule
+
+		beforeEach("create rule", () => {
+			rule = new Rule(
+				"incPrice",
+				engine.closures.get("dateRange").bind(null, {dateAfter: "2018-09-30", dateExtractor: "saleDate"}, engine),
+				engine.closures.get("priceInc")
+			)
+		})
+
+		it("should process on date way after dateAfter", () => {
+			const fact = { saleDate: "2018-12-15", price: 10 }
+			const newFact = rule.process(fact, context())
+			newFact.should.not.be.null
+			newFact.price.should.equal(11)
+		});
+
+		it("should process on date just after dateAfter", () => {
+			const fact = { saleDate: "2018-10-01", price: 10 }
+			const newFact = rule.process(fact, context())
+			newFact.should.not.be.null
+			newFact.price.should.equal(11)
+		});
+
+		it("should not process on dateAfter", () => {
+			const fact = { saleDate: "2018-09-30", price: 10 }
+			const newFact = rule.process(fact, context())
+			newFact.should.not.be.null
+			newFact.price.should.equal(10)
+		});
+
+		it("should not process on date just before dateAfter", () => {
+			const fact = { saleDate: "2018-09-29", price: 10 }
+			const newFact = rule.process(fact, context())
+			newFact.should.not.be.null
+			newFact.price.should.equal(10)
+		});
+
+		it("should not process on date way before dateAfter", () => {
+			const fact = { saleDate: "2018-07-21", price: 10 }
+			const newFact = rule.process(fact, context())
+			newFact.should.not.be.null
+			newFact.price.should.equal(10)
+		});
+
+	});
+
 });
 
 function context() {


### PR DESCRIPTION
now we have four options to define the range: dateFrom, dateTo, dateAfter and dateBefore.
E.g. "dateFrom" is >=, while "dateAfter" is strict >.
Hence, combining e.g. dateBefore and dateFrom, we can establish the validity range for two rules using the same date, e.g. dateBefore 2019-01-01 and dateFrom 2019-01-01 indicates that one rule applies up to 2018, and the other one from 2019 onwards.

Additionally, the four parameters are defined as closureParameters. Due of an earlier change, they accept either the name of a closure **or** a fixed date.